### PR TITLE
feat: add freight calculation

### DIFF
--- a/src/Item.ts
+++ b/src/Item.ts
@@ -3,6 +3,20 @@ export default class Item {
   constructor(
     readonly description: string,
     readonly price: number,
-    readonly quantity: number,
-  ) {}
+    readonly height,
+    readonly width,
+    readonly depth,
+    readonly weight,
+  ) {
+    if(this.height <= 0 || this.width <= 0 || this.depth <= 0)  throw new Error('Invalid dimension.')
+    if(this.weight <= 0)  throw new Error('Invalid weight.')
+  }
+
+  getVolume(): number {
+    return (this.height/100) * (this.width/100) * (this.depth/100);
+  }
+
+  getDensity(): number {
+    return parseFloat((this.weight / this.getVolume()).toFixed());
+  }
 }

--- a/src/Order.ts
+++ b/src/Order.ts
@@ -6,14 +6,22 @@ export default class Order {
   itens: Array<Item> = [];
   total = 0;
   customerCPF: CPF;
+  freight = 0;
 
   constructor(readonly orderCPF: string) {
     this.customerCPF = new CPF(orderCPF);
   }
 
-  addItem(item: Item): void {
-    this.itens.push(item);
-    this.total += item.price;
+  addItem(item: Item, quantity: number): void {
+    if (quantity > 0 && !this.existItemInList(item.description)) {
+      this.itens.push(item);
+      this.calculateFreight(item);
+      this.total += item.price * quantity;
+    }
+  }
+
+  existItemInList(itemName: string): boolean {
+    return this.itens.some((item) => item.description === itemName);
   }
 
   applyDiscountInPercentage(discountCoupon: Coupon): void {
@@ -23,11 +31,19 @@ export default class Order {
     }
   }
 
+  calculateFreight(item: Item): void {
+    this.freight += 1000 * item.getVolume() * (item.getDensity() / 100);
+  }
+
   getTotal(): number {
-    return this.total;
+    return parseFloat(this.total.toFixed(2));
   }
 
   getItens(): Array<Item> {
     return this.itens;
+  }
+
+  getFreight(): number {
+    return this.freight < 10 ? 10 : this.freight;
   }
 }

--- a/tests/Item.test.ts
+++ b/tests/Item.test.ts
@@ -1,0 +1,17 @@
+import Item from '../src/Item';
+
+// description, price, height, width, depth and weight
+
+describe('Item tests', () => {
+  it('Should not create a item if some dimension is negative', () => {
+    expect(() => new Item('Ipa', 24.52, 20, 8, -9, 1)).toThrowError(
+      new Error('Invalid dimension.'),
+    );
+  });
+
+  it('Should not create a item if weight is negative', () => {
+    expect(() => new Item('Ipa', 24.52, 20, 8, 6, -1)).toThrowError(
+      new Error('Invalid weight.'),
+    );
+  });
+});

--- a/tests/Order.test.ts
+++ b/tests/Order.test.ts
@@ -2,6 +2,8 @@ import Coupon from '../src/Coupon';
 import Item from '../src/Item';
 import Order from '../src/Order';
 
+// description, price, height, width, depth and weight
+
 describe('Order tests', () => {
   it('Should not create a order if CPF is invalid', () => {
     expect(() => new Order('253.318.570-10')).toThrowError(
@@ -11,16 +13,16 @@ describe('Order tests', () => {
 
   it('Should create a order with 3 itens', () => {
     const newOrder = new Order('073.711.920-95');
-    const item1 = new Item('Ipa', 5.75, 2);
-    const item2 = new Item('Apa', 4.5, 3);
-    const item3 = new Item('Double Ipa', 7.4, 4);
-    newOrder.addItem(item1);
-    newOrder.addItem(item2);
-    newOrder.addItem(item3);
+    const item1 = new Item('Ipa', 5.75, 20, 8, 9, 1);
+    const item2 = new Item('Apa', 4.5, 18, 6, 8, 1.5);
+    const item3 = new Item('Double Ipa', 7.4, 19, 9, 7, 2);
+    newOrder.addItem(item1, 1);
+    newOrder.addItem(item2, 2);
+    newOrder.addItem(item3, 1);
     expect(newOrder.getItens()).toHaveLength(3);
   });
 
-  describe('Discont', () => {
+  describe('Discont tests', () => {
     it('Should apply discount in the total of order', () => {
       const discontCoupon = new Coupon(
         'GET5',
@@ -28,14 +30,14 @@ describe('Order tests', () => {
         new Date('2022-15-11T12:00:00'),
       );
       const newOrder = new Order('073.711.920-95');
-      const item1 = new Item('Ipa', 24.52, 2);
-      const item2 = new Item('Apa', 27.23, 3);
-      const item3 = new Item('Double Ipa', 56, 4);
-      newOrder.addItem(item1);
-      newOrder.addItem(item2);
-      newOrder.addItem(item3);
+      const item1 = new Item('Ipa', 24.52, 20, 8, 9, 1);
+      const item2 = new Item('Apa', 27.23, 18, 6, 8, 1.5);
+      const item3 = new Item('Double Ipa', 56, 19, 9, 7, 2);
+      newOrder.addItem(item1, 1);
+      newOrder.addItem(item2, 2);
+      newOrder.addItem(item3, 1);
       newOrder.applyDiscountInPercentage(discontCoupon);
-      expect(newOrder.getTotal()).toBe(102.36);
+      expect(newOrder.getTotal()).toBe(128.23);
     });
 
     it('Should not apply discount if coupon is expired', () => {
@@ -45,12 +47,48 @@ describe('Order tests', () => {
         new Date('2022-01-11T12:00:00'),
       );
       const newOrder = new Order('073.711.920-95');
-      const item1 = new Item('Ipa', 5.75, 2);
-      const item2 = new Item('Apa', 4.5, 3);
-      newOrder.addItem(item1);
-      newOrder.addItem(item2);
+      const item1 = new Item('Ipa', 5.75, 20, 8, 9, 1);
+      const item2 = new Item('Apa', 4.5, 18, 6, 8, 1.5);
+      newOrder.addItem(item1, 1);
+      newOrder.addItem(item2, 3);
       newOrder.applyDiscountInPercentage(discontCoupon);
-      expect(newOrder.getTotal()).toBe(10.25);
+      expect(newOrder.getTotal()).toBe(19.25);
+    });
+  });
+
+  describe('Add item tests', () => {
+    it('Should not add item with negative quantity', () => {
+      const newOrder = new Order('073.711.920-95');
+      const item1 = new Item('Ipa', 24.52, 20, 8, 9, 1);
+      newOrder.addItem(item1, 2);
+      newOrder.addItem(item1, -5);
+      expect(newOrder.getItens()).toHaveLength(1);
+    });
+
+    it('Should not add item if item already exist in the list', () => {
+      const newOrder = new Order('073.711.920-95');
+      const item1 = new Item('Ipa', 24.52, 20, 8, 9, 1);
+      newOrder.addItem(item1, 2);
+      newOrder.addItem(item1, 5);
+      expect(newOrder.getItens()).toHaveLength(1);
+    });
+  });
+
+  describe('Freight tests', () => {
+    it('Should calculate the value of freight', () => {
+      const newOrder = new Order('073.711.920-95');
+      const item1 = new Item('Ipa', 24.52, 100, 30, 10, 3);
+      const item2 = new Item('Apa', 24.52, 20, 15, 10, 1);
+      newOrder.addItem(item1, 1);
+      newOrder.addItem(item2, 1);
+      expect(newOrder.getFreight()).toBe(39.99);
+    });
+
+    it('Should return the minimal value of freight', () => {
+      const newOrder = new Order('073.711.920-95');
+      const item2 = new Item('Apa', 24.52, 20, 15, 10, 1);
+      newOrder.addItem(item2, 1);
+      expect(newOrder.getFreight()).toBe(10);
     });
   });
 });


### PR DESCRIPTION
- You must not apply expired discount coupon
- When placing an order, the quantity of an item cannot be negative
- When placing an order, the same item cannot be entered more than once
- No item dimension can be negative
- The weight of the item can't be negative
- It should calculate the freight based on the dimensions (height, width and depth in cm) and the weight of the products (in kg)
- It must return the minimum freight price if it's higher than the calculated value